### PR TITLE
Integrate HikariCP connection pool in SpringBoot application

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,27 +20,25 @@ spring:
         username: root
         password: 1q2w3e4r
         driver-class-name: com.mysql.cj.jdbc.Driver
-        druid:
-            max-active: 10
-            min-idle: 5
-            max-wait: 10000
-            initial-size: 5
-            validation-query: select 1
-            stat-view-servlet:
-                enabled: true
-                #        login-username: admin
-                #        login-password: admin
-                #        allow:
-                #        deny:
-                url-pattern: "/druid/*"
-                allow: 47.95.110.151
-            web-stat-filter:
-                enabled: true
-                url-pattern: "/druid/**"
-                exclusions: '*.js,*.gif,*.jpg,*.jpeg,*.png,*.css,*.ico,*.jsp,/druid/*'
-                principal-session-name: ''
-                session-stat-enable: true
-                session-stat-max-count: 1000
+        # hikari连接池配置
+        hikari:
+            #连接池名
+            pool-name: HikariCP
+            #最小空闲连接数
+            minimum-idle: 5
+            # 空闲连接存活最大时间，默认10分钟
+            idle-timeout: 600000
+            # 连接池最大连接数，默认是10
+            maximum-pool-size: 10
+            # 此属性控制从池返回的连接的默认自动提交行为,默认值：true
+            auto-commit: true
+            # 此属性控制池中连接的最长生命周期，值0表示无限生命周期，默认30分钟
+            max-lifetime: 1800000
+            # 数据库连接超时时间,默认30秒
+            connection-timeout: 30000
+            # 连接测试query
+            connection-test-query: SELECT 1
+
 #mybatisplus的配置
 mybatis-plus:
     configuration:


### PR DESCRIPTION
Related to #3

Integrate HikariCP connection pool into the SpringBoot application.

* Remove Druid-specific configuration from `src/main/resources/application.yml`.
* Add HikariCP configuration under `spring.datasource.hikari` in `src/main/resources/application.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BuleStar/hfai/issues/3?shareId=8d775b0c-82fe-4d96-a425-b69acace7989).